### PR TITLE
set connection commitment to "confirmed"

### DIFF
--- a/scripts/createAndMint.ts
+++ b/scripts/createAndMint.ts
@@ -58,7 +58,7 @@ let initBalance: number, balance: number;
   const CLUSTER_URL = process.env.RPC_URL ?? clusterApiUrl("devnet");
 
   // create a new rpc connection, using the ReadApi wrapper
-  const connection = new WrapperConnection(CLUSTER_URL);
+  const connection = new WrapperConnection(CLUSTER_URL, "confirmed");
 
   // get the payer's starting balance (only used for demonstration purposes)
   initBalance = await connection.getBalance(payer.publicKey);

--- a/scripts/verboseCreateAndMint.ts
+++ b/scripts/verboseCreateAndMint.ts
@@ -80,7 +80,7 @@ let initBalance: number, balance: number;
   const CLUSTER_URL = process.env.RPC_URL ?? clusterApiUrl("devnet");
 
   // create a new rpc connection, using the ReadApi wrapper
-  const connection = new WrapperConnection(CLUSTER_URL);
+  const connection = new WrapperConnection(CLUSTER_URL, "confirmed");
 
   //////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
@@ -126,11 +126,11 @@ let initBalance: number, balance: number;
   //////////////////////////////////////////////////////////////////////////////
 
   /*
-    For demonstration purposes, we can compute how much space our tree will 
-    need to allocate to store all the records. As well as the cost to allocate 
+    For demonstration purposes, we can compute how much space our tree will
+    need to allocate to store all the records. As well as the cost to allocate
     this space (aka minimum balance to be rent exempt)
     ---
-    NOTE: These are performed automatically when using the `createAllocTreeIx` 
+    NOTE: These are performed automatically when using the `createAllocTreeIx`
     function to ensure enough space is allocated, and rent paid.
   */
 


### PR DESCRIPTION
Set connection commitment to "confirmed" in `createAndMint.ts` and `verboseCreateAndMint.ts`.

Seems like calling the `createCollection` helper function throw errors if commitment not explicitly set to "confirmed" due to the `createAccount` and `mintTo` functions get called before network recognizes the mint / token account are created.

https://github.com/solana-developers/compressed-nfts/blob/master/utils/compression.ts#L119

```
logs: [
    'Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]',
    'Program log: Create',
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]',
    'Program log: Instruction: GetAccountDataSize',
    'Program log: Error: IncorrectProgramId',
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 884 of 191633 compute units',
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: incorrect program id for instruction',
    'Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 9251 of 200000 compute units',
    'Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL failed: incorrect program id for instruction'
  ]
```

```
  logs: [
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]',
    'Program log: Instruction: MintTo',
    'Program log: Error: InvalidAccountData',
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 1260 of 200000 compute units',
    'Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: invalid account data for instruction'
  ]
```

